### PR TITLE
Add status update on disconnect and error check

### DIFF
--- a/lib/tcpConnectedClient.js
+++ b/lib/tcpConnectedClient.js
@@ -21,10 +21,11 @@ class TCPConnectedClient {
 
   closeConnection () {
     this.socket.destroy()
+    console.log(this.name + ' Disconnected')
   }
 
   handleResponse (response) {
-    this.receiveMessage(response.toString())
+    if (response !== undefined) this.receiveMessage(response.toString())
     if (response === this.QUIT_CODE) this.closeConnection()
   }
 }

--- a/test/tcpConnectedClient.test.js
+++ b/test/tcpConnectedClient.test.js
@@ -62,6 +62,12 @@ describe('TCPClient', () => {
       client.closeConnection()
       expect(mockDestroy).toHaveBeenCalledTimes(1)
     })
+    it("calls console.log to notify dicsconnection", () => {
+      console.log = jest.fn()
+      client.closeConnection()
+      expect(console.log).toHaveBeenCalledWith(`127.0.0.0:5001 Disconnected`)
+    })
+
   })
 
   describe('handleResponse', () => {
@@ -80,6 +86,12 @@ describe('TCPClient', () => {
     it('keeps connection open when not a 221 reponse', () => {
       client.handleResponse(response)
       expect(mockDestroy).toHaveBeenCalledTimes(0)
+    })
+    it('does not run #receiveMessage if response is undefined', function () {
+      let response = undefined
+      receveMessageSpy = jest.spyOn(client, 'receiveMessage')
+      client.handleResponse(response)
+      expect(receveMessageSpy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Add status update to the SMTP server to indicate when the external client disconnects from the server.

Add an error check to account for a fact that a response received by the server may be 'undefined' which was previously causing the server to fail as it was trying to convert underfined toString()

closes #24 